### PR TITLE
fix: missing permissions on azurerm_storage_account_sas resource

### DIFF
--- a/modules/functionapp/r-storage.tf
+++ b/modules/functionapp/r-storage.tf
@@ -78,5 +78,7 @@ data "azurerm_storage_account_sas" "package_sas" {
     create  = false
     update  = false
     process = false
+    tag     = false
+    filter  = false
   }
 }


### PR DESCRIPTION
Since the release of the terraform azurerm provider 3.0, terraform resource `storage_account_sas` must have both `tag` and `filter` permissions configured : https://registry.terraform.io/providers/hashicorp/azurerm/3.0.0/docs/data-sources/storage_account_sas .

This PR fixes it by adding these 2 permissions to the `storage_account_sas` resource.